### PR TITLE
Add an error handler module to rescue frequently raised exceptions

### DIFF
--- a/lib/error_handler.rb
+++ b/lib/error_handler.rb
@@ -14,7 +14,16 @@ module ErrorHandler
   #     end
   #   end
   # end
-  def handle_errors
-    yield
+
+  def handle_errors(rules)
+    rules = Array(rules)
+
+    raise ArgumentError.new("All rules must be Procs") unless rules.all?{|r| r.is_a?(Proc)}
+
+    begin
+      yield
+    rescue => e
+      raise e unless rules.any?{ |r| r.(e) }
+    end
   end
 end

--- a/spec/error_handler_spec.rb
+++ b/spec/error_handler_spec.rb
@@ -1,9 +1,92 @@
 require "error_handler"
 
 describe ErrorHandler do
+  let(:subject) { rescuable.new.process(rules) }
+  let(:rules) { [] }
+  let(:rescuable) do
+    Class.new do
+      include ErrorHandler
+
+      def process(rules)
+        handle_errors(rules) do
+          raise IOError.new "Something went wrong"
+        end
+      end
+    end
+  end
+
   it "is an object" do
     expect(ErrorHandler).to be_a(Object)
   end
 
-  # TODO: please add your tests here
+  context "when no rules are provided" do
+    it "raises the exception" do
+      expect { subject }.to raise_error(IOError)
+    end
+  end
+
+  context "when rules are provided" do
+    context "when rule is not a Proc" do
+      let(:rules) do
+        [
+          ->(e) { e.is_a?(IOError) },
+          "Not a Proc"
+        ]
+      end
+
+      it "raises an exception" do
+        expect { subject }.to raise_error(ArgumentError, "All rules must be Procs")
+      end
+    end
+
+
+    context "when there is only one rule" do
+      let(:rules) do
+        ->(e) { e.is_a?(IOError) }
+      end
+
+      it "is fine if it's not in an array" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when all rules match" do
+      let(:rules) do
+        [
+          ->(e) { e.is_a?(IOError) },
+          ->(e) { e.message == "Something went wrong" }
+        ]
+      end
+
+      it "rescues the exception" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when some rules match" do
+      let(:rules) do
+        [
+          ->(e) { e.is_a?(IOError) },
+          ->(e) { e.message == "Everything is fine" }
+        ]
+      end
+
+      it "rescues the exception" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when no rules match" do
+      let(:rules) do
+        [
+          ->(e) { e.is_a?(ArgumentError) },
+          ->(e) { e.message == "Everything is fine" }
+        ]
+      end
+
+      it "raises the exception" do
+        expect { subject }.to raise_error(IOError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Our application frequently raises exceptions that are "expected". We are aware of those errors and decided that they are safe to ignore.

Because our monitoring system sends us notifications for each application error, we run the risk to miss important ones if we are flooded with errors we don't need to worry about.

This Pull Request adds an `ErrorHandler` module that can be mixed-in in any class that is known to frequently raise expected errors. The module provides a method to wrap a block of code, and, conditionally rescue exceptions raised within that block.

Use `handle_errors` to wrap blocks of code that are known to raise expected exceptions. Provide an array of rules as `Procs` to indicate which exceptions should be rescued. If any rule matches (OR), the exception will be rescued. Otherwise, it will be re-raised. If the same rules are used for multiple classes, they can be extracted into a module.

```ruby
class JsonParser
  include ErrorHandler

  def parse
    handle_errors([->(e) {e.is_a?(IOError)}]) do
      # Code that often raises an IOError
    end
  end
end
```